### PR TITLE
Update category filter options to take into account the data that is already filtered by the pocket filter

### DIFF
--- a/app/(main)/move/page.tsx
+++ b/app/(main)/move/page.tsx
@@ -51,9 +51,9 @@ export default async function Home() {
       ),
       type: resource.type.name,
       damageClass: resource.damage_class.name,
-      power: resource.power ?? undefined,
-      accuracy: resource.accuracy ?? undefined,
-      pp: resource.pp ?? undefined,
+      power: resource.power || undefined,
+      accuracy: resource.accuracy || undefined,
+      pp: resource.pp!,
     }))
     .sort((a, b) => a.name.localeCompare(b.name))
 

--- a/components/compounds/ItemCardGrid.tsx
+++ b/components/compounds/ItemCardGrid.tsx
@@ -115,8 +115,14 @@ export default function ItemCardGrid({
       })
     }
 
+    // Filter data by pocket filters first, then get available categories
+    const pocketFilteredData =
+      pocketFilters.length > 0
+        ? data.filter((item) => pocketFilters.includes(item.pocket))
+        : data
+
     const uniqueCategories = Array.from(
-      new Set(data.map((item) => item.category))
+      new Set(pocketFilteredData.map((item) => item.category))
     )
 
     if (uniqueCategories.length > 0) {

--- a/components/details/moves/MovesSection.tsx
+++ b/components/details/moves/MovesSection.tsx
@@ -58,8 +58,8 @@ function createMoveRows(
           flavorTextEntries: move.flavor_text_entries.filter(
             (entry) => entry.language.name === 'en'
           ),
-          power: move.power ?? undefined,
-          accuracy: move.accuracy ?? undefined,
+          power: move.power || undefined,
+          accuracy: move.accuracy || undefined,
           pp: move.pp!,
         })
       }


### PR DESCRIPTION
This pull request includes changes to improve data filtering and consistency in handling optional properties across multiple components. The updates enhance code readability and ensure proper handling of undefined values.

### Consistency in handling optional properties:
* Updated the handling of `power`, `accuracy`, and `pp` properties in `app/(main)/move/page.tsx` to use `||` instead of `??` for defaulting to `undefined` and added the non-null assertion operator for `pp`. (`[app/(main)/move/page.tsxL54-R56](diffhunk://#diff-837d212663042bd4b7753e05b12238f9d1bedfa38f73f978400a2d9ff3653f6bL54-R56)`)
* Applied similar changes to `power`, `accuracy`, and `pp` properties in `components/details/moves/MovesSection.tsx` for consistency. (`[components/details/moves/MovesSection.tsxL61-R62](diffhunk://#diff-c2f6cad430432f14104e23477ec2d4e13aa62357b7f875abecd37fd8b6065fb0L61-R62)`)

### Data filtering improvements:
* Added filtering logic to `components/compounds/ItemCardGrid.tsx` to filter data by `pocketFilters` before determining unique categories, ensuring that category calculations respect applied filters. (`[components/compounds/ItemCardGrid.tsxR118-R125](diffhunk://#diff-4b96c75c201972d9c813768ffca641b9c3b7522a40d95bbcf66ab0a8987fa3edR118-R125)`)