### PR TITLE
Fix responsive margin class for radar chart container

### DIFF
--- a/components/details/stats/StatsRadarChart.tsx
+++ b/components/details/stats/StatsRadarChart.tsx
@@ -121,7 +121,7 @@ export default function StatsRadarChart({ pokemon }: { pokemon: Pokemon }) {
   }
 
   return (
-    <div className="2xs:ml-0 relative mt-8 mb-4 -ml-2">
+    <div className="xs:ml-0 relative mt-8 mb-4 -ml-2">
       <svg
         width={RADAR_SIZE}
         height={RADAR_SIZE}


### PR DESCRIPTION
This pull request includes a small change to the `StatsRadarChart` component. The change updates the CSS class from `2xs:ml-0` to `xs:ml-0` to adjust the styling for a different breakpoint.