### PR TITLE
Change bun to pnpm in documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,8 +1,8 @@
 ## Project specific
 
-- Framework: Next.js 15
+- Framework: Next.js 16
 - Language: TypeScript 5
-- Core packages: Tailwind CSS 4.1, React 19, Bun 1.2, TanStack Table, pMap, clsx, lucide-react
+- Core packages: Tailwind CSS 4.1, React 19, pnpm, TanStack Table, pMap, clsx, lucide-react
 - The project is a web application that uses Next.js only for its static exports (SSG) and does not use any server-side rendering (SSR) or API routes in production. Server-side rendering (SSR) is only used for development purposes.
 - Do not suggest using `generateStaticParams` as that is no longer supported in Next.js 15. Instead, Next.js 15 encourages fetching data directly in the page component using `async/await`.
 - Favor using `type` over `interface` unless necessary.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,8 +5,8 @@
       "name": "Next.js: debug server-side",
       "type": "node-terminal",
       "request": "launch",
-      // "command": "$env:NODE_OPTIONS='--inspect'; bun --bun run dev"
-      "command": "$env:NODE_OPTIONS='--inspect'; bun run dev"
+      // "command": "$env:NODE_OPTIONS='--inspect'; pnpm --node-options=--inspect dev"
+      "command": "$env:NODE_OPTIONS='--inspect'; pnpm dev"
     },
     {
       "name": "Next.js: debug client-side",

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@
 - 🖼️ **Rich UI Components**: Responsive cards, charts, icons, and pills for a delightful user experience.
 - 🌗 **Dark/Light Theme**: Toggle between themes for comfortable browsing.
 - 📦 **Static Export**: Blazing fast static site generation (SSG) for production.
-- 🛠️ **Developer Friendly**: Built with TypeScript, Bun, TanStack Table, pMap, clsx/lite, lucide-react, and more.
+- 🛠️ **Developer Friendly**: Built with TypeScript, pnpm, TanStack Table, pMap, clsx/lite, lucide-react, and more.
 
 ## Tech Stack
 
-- **Framework**: Next.js 15 (SSG only, SSR for development)
+- **Framework**: Next.js 16 (SSG only, SSR for development)
 - **Language**: TypeScript 5
 - **Styling**: Tailwind CSS v4
-- **Runtime**: Bun 1.2
+- **Package Manager**: pnpm
 - **UI**: React, lucide-react
 - **Tables**: TanStack Table
 - **Utils**: pMap, clsx/lite
@@ -36,13 +36,13 @@
 
 ### Prerequisites
 
-- [Bun](https://bun.sh/) >= 1.2
+- [pnpm](https://pnpm.io/) >= 10
 
 ### Install & Run
 
 ```sh
-bun install
-bun dev
+pnpm install
+pnpm dev
 ```
 
 Visit [http://localhost:3000](http://localhost:3000) to view the app.
@@ -50,8 +50,7 @@ Visit [http://localhost:3000](http://localhost:3000) to view the app.
 ### Build Static Site
 
 ```sh
-bun run build
-bun run export
+pnpm build
 ```
 
 Static files will be generated in the `out/` directory.


### PR DESCRIPTION
This pull request updates the project to use Next.js 16 and switches the package manager and runtime from Bun to pnpm. Documentation and configuration files have been updated to reflect these changes.

**Framework and Tooling Updates:**

* Upgraded the framework from Next.js 15 to Next.js 16 in `.github/copilot-instructions.md` and `README.md`. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L3-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R23)
* Replaced Bun with pnpm as the package manager throughout the project, including updates in `.github/copilot-instructions.md`, `README.md`, and `.vscode/launch.json`. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L3-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R23) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R53) [[4]](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L8-R9)

**Documentation and Configuration:**

* Updated installation and development commands in `README.md` and `.vscode/launch.json` to use pnpm instead of Bun. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R53) [[2]](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L8-R9)
* Adjusted the list of core packages and prerequisites in documentation to match the new stack. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L3-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R23) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R53)