### PR TITLE
Fix site path and base url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,3 @@
 NODE_ENV=production
-NEXT_PUBLIC_BASEPATH=
-NEXT_PUBLIC_FULL_URL=http://localhost:3000
+PUBLIC_SITE_URL=http://localhost:3000
 PUBLIC_BASEPATH=
-PUBLIC_FULL_URL=http://localhost:3000

--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 env:
+  PUBLIC_SITE_URL: https://blai30.github.io
   PUBLIC_BASEPATH: /masterball
-  PUBLIC_FULL_URL: https://blai30.github.io
 
 permissions:
   contents: read
@@ -28,7 +28,7 @@ jobs:
         uses: withastro/action@v6
         with:
           package-manager: pnpm@11.1.0
-          node-version: 22
+          node-version: 24
 
   deploy:
     environment:

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,7 +3,8 @@ import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'astro/config'
 
 export default defineConfig({
-  base: process.env.PUBLIC_BASEPATH || '/',
+  site: process.env.PUBLIC_SITE_URL,
+  base: process.env.PUBLIC_BASEPATH,
   devToolbar: {
     enabled: false,
   },


### PR DESCRIPTION
This pull request updates environment variable usage and deployment configuration to improve consistency and compatibility with the Astro framework and deployment workflows. The main changes involve standardizing the use of `PUBLIC_SITE_URL` instead of previous URL-related variables, updating the Node.js version for deployment, and aligning the Astro config with these changes.

**Environment variable standardization:**

* Replaced `NEXT_PUBLIC_BASEPATH` and `NEXT_PUBLIC_FULL_URL` with `PUBLIC_SITE_URL` in `.env.example` for consistency and clarity.
* Updated workflow environment variables in `.github/workflows/astro.yml` to use `PUBLIC_SITE_URL` and removed `PUBLIC_FULL_URL`.

**Deployment and configuration updates:**

* Changed the Node.js version used in the Astro GitHub Actions workflow from 22 to 24 for compatibility with newer features and dependencies.
* Updated `astro.config.mjs` to use `process.env.PUBLIC_SITE_URL` for the `site` configuration and set the `base` path using `PUBLIC_BASEPATH`, ensuring the Astro site is configured correctly for deployment.