### PR TITLE
Add helpers to resolve url paths

### DIFF
--- a/src/components/DamageClassIcon.tsx
+++ b/src/components/DamageClassIcon.tsx
@@ -30,7 +30,7 @@ export default function DamageClassIcon({
   className?: string
 }) {
   const name = DamageClassLabels[variant as DamageClassKey]
-  const imageUrl = `${import.meta.env.BASE_URL}${variant}.png`
+  const imageUrl = `${variant}.png`
   const dimensions = {
     small: 20,
     medium: 28,

--- a/src/components/MonsterPill.tsx
+++ b/src/components/MonsterPill.tsx
@@ -3,6 +3,7 @@ import type { Pokemon, PokemonSpecies } from 'pokedex-promise-v2'
 import GlassCard from '@/components/GlassCard'
 import TypeIcon from '@/components/TypeIcon'
 import Link from '@/components/ui/catalyst/link'
+import { toHref } from '@/lib/utils/path'
 import { getTranslation, type TypeKey } from '@/lib/utils/pokeapi-helpers'
 
 export default function MonsterPill({
@@ -18,7 +19,7 @@ export default function MonsterPill({
 
   return (
     <GlassCard variant="link" className="rounded-lg">
-      <Link href={`${import.meta.env.BASE_URL}${species.name}`} className="group flex w-56 items-center gap-3 px-3 py-2">
+      <Link href={toHref(species.name)} className="group flex w-56 items-center gap-3 px-3 py-2">
         <img
           src={imageUrl}
           alt={species.name}

--- a/src/components/TypeIcon.tsx
+++ b/src/components/TypeIcon.tsx
@@ -45,7 +45,7 @@ export default function TypeIcon({
   className?: string
 }) {
   const name = TypeLabels[variant as TypeKey]
-  const imageUrl = `${import.meta.env.BASE_URL}${variant}.png`
+  const imageUrl = `${variant}.png`
   const dimensions = {
     small: 20,
     medium: 28,

--- a/src/components/TypePill.tsx
+++ b/src/components/TypePill.tsx
@@ -44,7 +44,7 @@ export default function TypePill({
   className?: string
 }) {
   const name = TypeLabels[variant as TypeKey]
-  const imageUrl = `${import.meta.env.BASE_URL}${variant}.png`
+  const imageUrl = `${variant}.png`
   const dimensions = {
     small: 20,
     medium: 24,

--- a/src/components/compounds/MonsterCard.tsx
+++ b/src/components/compounds/MonsterCard.tsx
@@ -3,6 +3,7 @@ import { memo } from 'react'
 
 import GlassCard from '@/components/GlassCard'
 import Link from '@/components/ui/catalyst/link'
+import { toHref } from '@/lib/utils/path'
 import type { TypeKey } from '@/lib/utils/pokeapi-helpers'
 
 export type MonsterCardProps = {
@@ -20,7 +21,7 @@ const MonsterCard = ({ props }: { props: MonsterCardProps }) => {
   return (
     <GlassCard variant="link" className="h-full rounded-xl">
       <Link
-        href={`${import.meta.env.BASE_URL}${props.slug}`}
+        href={toHref(props.slug)}
         className="group flex flex-col items-center justify-between px-2 py-3"
       >
         <p aria-hidden="true" className="font-num text-xs text-zinc-400 dark:text-zinc-500">

--- a/src/components/compounds/MoveCard.tsx
+++ b/src/components/compounds/MoveCard.tsx
@@ -85,7 +85,7 @@ export default function MoveCard({ props }: { props: MoveInfo }) {
                 {DamageClassLabels[props.damageClass as DamageClassKey]}
               </span>
               <img
-                src={`${import.meta.env.BASE_URL}${props.damageClass}.png`}
+                src={`${props.damageClass}.png`}
                 alt={DamageClassLabels[props.damageClass as DamageClassKey]}
                 width={128}
                 height={128}

--- a/src/components/compounds/VariantCardSelector.tsx
+++ b/src/components/compounds/VariantCardSelector.tsx
@@ -1,8 +1,10 @@
 import { Radio, RadioGroup } from '@headlessui/react'
+import { navigate } from 'astro:transitions/client'
 import clsx from 'clsx/lite'
 import { useState } from 'react'
 
 import VariantCard from '@/components/compounds/VariantCard'
+import { normalizePathname, resolvePath } from '@/lib/utils/path'
 import type { Monster } from '@/lib/utils/pokeapi-helpers'
 
 export default function VariantCardSelector({
@@ -14,17 +16,15 @@ export default function VariantCardSelector({
   pathname: string
   className?: string
 }) {
-  const [selectedVariant, setSelectedVariant] = useState<string>(pathname)
+  const [selectedVariant, setSelectedVariant] = useState<string>(normalizePathname(pathname))
 
   const handleVariantChange = (url: string) => {
     setSelectedVariant(url)
-    window.location.href = url
+    navigate(resolvePath(url))
   }
 
   const getUrl = (monster: Monster) =>
-    monster.formSlug
-      ? `${import.meta.env.BASE_URL}${monster.speciesSlug}/${monster.formSlug}`
-      : `${import.meta.env.BASE_URL}${monster.speciesSlug}`
+    monster.formSlug ? `/${monster.speciesSlug}/${monster.formSlug}` : `/${monster.speciesSlug}`
 
   return (
     <RadioGroup

--- a/src/components/shared/NavMenu.tsx
+++ b/src/components/shared/NavMenu.tsx
@@ -15,6 +15,7 @@ import {
   SidebarLabel,
   SidebarSection,
 } from '@/components/ui/catalyst/sidebar'
+import { normalizePathname, toHref } from '@/lib/utils/path'
 
 const ThemeSwitch = lazy(() => import('@/components/shared/ThemeSwitch'))
 
@@ -26,14 +27,16 @@ const navItems = [
 ]
 
 function NavMenu({ variant, pathname }: { variant: 'navbar' | 'sidebar'; pathname: string }) {
+  const currentPathname = normalizePathname(pathname)
+
   const isActiveRoute = (url: string) => {
     if (url === '/') {
       return (
-        pathname === '/' ||
-        !navItems.some((item) => item.url !== '/' && pathname.startsWith(item.url))
+        currentPathname === '/' ||
+        !navItems.some((item) => item.url !== '/' && currentPathname.startsWith(item.url))
       )
     }
-    return pathname.startsWith(url)
+    return currentPathname.startsWith(url)
   }
 
   // Navbar variant for desktop
@@ -44,7 +47,7 @@ function NavMenu({ variant, pathname }: { variant: 'navbar' | 'sidebar'; pathnam
           {navItems.map((item) => {
             const active = isActiveRoute(item.url)
             return (
-              <NavbarItem key={item.url} href={item.url} current={active}>
+              <NavbarItem key={item.url} href={toHref(item.url)} current={active}>
                 <item.icon size={20} />
                 <NavbarLabel>{item.label}</NavbarLabel>
               </NavbarItem>
@@ -69,7 +72,7 @@ function NavMenu({ variant, pathname }: { variant: 'navbar' | 'sidebar'; pathnam
         {navItems.map((item) => {
           const active = isActiveRoute(item.url)
           return (
-            <SidebarItem key={item.url} href={item.url} current={active}>
+            <SidebarItem key={item.url} href={toHref(item.url)} current={active}>
               <item.icon size={20} />
               <SidebarLabel>{item.label}</SidebarLabel>
             </SidebarItem>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -23,10 +23,11 @@ const canonicalUrl = new URL(Astro.url.pathname, siteUrl)
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="dark" />
+    <base href={import.meta.env.BASE_URL} />
     <title>{title}</title>
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalUrl} />
-    <link rel="icon" type="image/png" href={`${import.meta.env.BASE_URL}favicon.png`} />
+    <link rel="icon" type="image/png" href="favicon.png" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />

--- a/src/lib/utils/path.ts
+++ b/src/lib/utils/path.ts
@@ -1,0 +1,22 @@
+// Centralized path helpers keep internal routes and asset URLs working
+// both at the site root in development and under the production subpath.
+
+const { BASE_URL } = import.meta.env
+
+export const toHref = (path: string) => path.replace(/^\/+/, '')
+
+export const normalizePathname = (pathname: string) => {
+  if (BASE_URL === '/') return pathname
+  if (pathname === BASE_URL.slice(0, -1)) return '/'
+  if (!pathname.startsWith(BASE_URL)) return pathname
+
+  const normalizedPathname = pathname.slice(BASE_URL.length - 1)
+  return normalizedPathname.startsWith('/') ? normalizedPathname : `/${normalizedPathname}`
+}
+
+export const resolvePath = (path: string) => {
+  const relativePath = toHref(path)
+  return typeof document === 'undefined'
+    ? relativePath
+    : new URL(relativePath, document.baseURI).pathname
+}


### PR DESCRIPTION
This pull request refactors how internal paths and asset URLs are handled throughout the codebase to ensure consistent routing and asset resolution, both during development (site root) and in production (potentially under a subpath). The changes centralize path manipulation logic into new utility functions, and update components to use these helpers, improving maintainability and reducing the risk of path-related bugs.

**Path Handling Improvements:**

* Added centralized path utilities in `src/lib/utils/path.ts`, including `toHref`, `normalizePathname`, and `resolvePath`, to standardize route and asset URL handling across the app.
* Updated navigation logic in `src/components/shared/NavMenu.tsx` to use `normalizePathname` for consistent active route detection and `toHref` for generating navigation links. [[1]](diffhunk://#diff-cda572493297b1dfbc97fea5b78e121b4bef17388d6444d1319f0f8088255968R18) [[2]](diffhunk://#diff-cda572493297b1dfbc97fea5b78e121b4bef17388d6444d1319f0f8088255968R30-R39) [[3]](diffhunk://#diff-cda572493297b1dfbc97fea5b78e121b4bef17388d6444d1319f0f8088255968L47-R50) [[4]](diffhunk://#diff-cda572493297b1dfbc97fea5b78e121b4bef17388d6444d1319f0f8088255968L72-R75)
* Refactored `src/components/compounds/VariantCardSelector.tsx` to use `normalizePathname` for state initialization, `resolvePath` and `navigate` for route changes, and simplified URL construction for monster variants. [[1]](diffhunk://#diff-b93b662a87f5b2452ccd6b5d87e62539684f8081e8917a49d25df0b11f0fcca2R2-R7) [[2]](diffhunk://#diff-b93b662a87f5b2452ccd6b5d87e62539684f8081e8917a49d25df0b11f0fcca2L17-R27)

**Asset URL Simplification:**

* Removed use of `import.meta.env.BASE_URL` from image and favicon URLs in multiple components (e.g., `TypeIcon`, `DamageClassIcon`, `TypePill`, `MoveCard`, and layout), now referencing assets with relative paths for consistency with the new `<base>` tag. [[1]](diffhunk://#diff-52b2c276af58885d0e0c79513e39a344ffc0700f8344596cc25c3f64dda5fc0fL48-R48) [[2]](diffhunk://#diff-a5a3db0b5779e8e2312c17f9504f3026af351dfbf4eff8ff302b586f63d106d7L33-R33) [[3]](diffhunk://#diff-ad00008a98f85ac5dff5a74fa5c6636ccc971dd9fe59678e7c8e2abdf063d4f1L47-R47) [[4]](diffhunk://#diff-2ae5a2662da5f25b230c1f8d0caef659120f2bcd9b0cb7417c5c8bc788c430ddL88-R88) [[5]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2R26-R30)

**Component Link Updates:**

* Updated links in `MonsterPill` and `MonsterCard` components to use the new `toHref` utility for constructing internal hrefs, ensuring proper routing regardless of deployment path. [[1]](diffhunk://#diff-e266f782570e99e879ba7c401b1ff1d3df577ce48fce504ee6c14e6b181bdfdcR6) [[2]](diffhunk://#diff-e266f782570e99e879ba7c401b1ff1d3df577ce48fce504ee6c14e6b181bdfdcL21-R22) [[3]](diffhunk://#diff-b6d84052ca0c7a531827cbf8cce26410f3a2b381f40fb04633a69e0ea7273783R6) [[4]](diffhunk://#diff-b6d84052ca0c7a531827cbf8cce26410f3a2b381f40fb04633a69e0ea7273783L23-R24)

**HTML Base Tag Addition:**

* Added a `<base>` tag in `src/layouts/Layout.astro` to set the base URL for all relative links and assets, further supporting correct path resolution in different environments.