### PR TITLE
Dev

### DIFF
--- a/src/components/compounds/MonsterCard.tsx
+++ b/src/components/compounds/MonsterCard.tsx
@@ -33,6 +33,7 @@ const MonsterCard = ({ props }: { props: MonsterCardProps }) => {
             height={128}
             className="object-contain"
             fetchPriority="high"
+            style={{ viewTransitionName: `pokemon-sprite-${props.slug}` }}
           />
         </div>
         <h3 className="text-sm font-semibold text-zinc-700 dark:text-zinc-300">{props.name}</h3>

--- a/src/components/compounds/VariantCardSelector.tsx
+++ b/src/components/compounds/VariantCardSelector.tsx
@@ -1,9 +1,8 @@
-import { Radio, RadioGroup } from '@headlessui/react'
-import { navigate } from 'astro:transitions/client'
 import clsx from 'clsx/lite'
 
 import VariantCard from '@/components/compounds/VariantCard'
-import { normalizePathname, resolvePath } from '@/lib/utils/path'
+import Link from '@/components/ui/catalyst/link'
+import { normalizePathname } from '@/lib/utils/path'
 import type { Monster } from '@/lib/utils/pokeapi-helpers'
 
 export default function VariantCardSelector({
@@ -17,39 +16,35 @@ export default function VariantCardSelector({
 }) {
   const selectedVariant = normalizePathname(pathname)
 
-  const handleVariantChange = (url: string) => {
-    if (url === selectedVariant) return
-    navigate(resolvePath(url))
-  }
-
   const getUrl = (monster: Monster) =>
     monster.formSlug ? `/${monster.speciesSlug}/${monster.formSlug}` : `/${monster.speciesSlug}`
 
   return (
-    <RadioGroup
-      value={selectedVariant}
-      onChange={handleVariantChange}
-      className={clsx('flex flex-row gap-2 py-4', className)}
-    >
+    <div className={clsx('flex flex-row gap-2 py-4', className)}>
       {monsters.map((monster) => (
-        <Radio
+        <Link
           key={monster.key}
-          value={getUrl(monster)}
+          // href={getUrl(monster)}
           aria-label={monster.name}
+          onClick={(e) => {
+            e.preventDefault()
+            window.location.replace(getUrl(monster))
+          }}
           className={clsx(
-            'group relative flex cursor-pointer justify-center rounded-xl focus:outline-offset-4 data-checked:cursor-default'
+            'group relative flex justify-center rounded-xl focus:outline-offset-4',
+            selectedVariant === getUrl(monster) ? 'cursor-default' : 'cursor-pointer'
           )}
+          aria-current={selectedVariant === getUrl(monster) ? 'page' : undefined}
         >
           <VariantCard
             monster={monster}
             className={clsx(
-              // 'rounded-xl',
-              'group-data-checked:bg-inherit group-data-checked:inset-ring-2 group-data-checked:inset-ring-zinc-700 dark:group-data-checked:inset-ring-zinc-300'
+              'group-aria-[current=page]:bg-inherit group-aria-[current=page]:inset-ring-2 group-aria-[current=page]:inset-ring-zinc-700 dark:group-aria-[current=page]:inset-ring-zinc-300'
             )}
             variant={selectedVariant === getUrl(monster) ? 'default' : 'link'}
           />
-        </Radio>
+        </Link>
       ))}
-    </RadioGroup>
+    </div>
   )
 }

--- a/src/components/details/MonsterHero.tsx
+++ b/src/components/details/MonsterHero.tsx
@@ -63,6 +63,7 @@ export default function MonsterHero({
           height={128}
           loading="eager"
           className="object-scale-down"
+          style={{ viewTransitionName: `pokemon-sprite-${species.name}` }}
         />
       </div>
     </div>

--- a/src/components/shared/ThemeSwitch.tsx
+++ b/src/components/shared/ThemeSwitch.tsx
@@ -32,12 +32,14 @@ const options = [
 ]
 
 export default function ThemeSwitch() {
-  const [theme, setTheme] = useState<ThemeValue>('system')
+  const [theme, setTheme] = useState<ThemeValue>()
 
   useEffect(() => {
     const stored = (localStorage.getItem('theme') as ThemeValue) ?? 'system'
     setTheme(stored)
   }, [])
+
+  if (theme === undefined) return null
 
   const handleThemeChange = (value: ThemeValue) => {
     setTheme(value)

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -54,7 +54,7 @@ const canonicalUrl = new URL(Astro.url.pathname, siteUrl)
       })()
     </script>
   </head>
-  <body>
+  <body class="antialiased text-black dark:bg-black dark:text-white">
     <slot />
   </body>
 </html>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -13,8 +13,7 @@ const {
   imageUrl,
 } = Astro.props
 
-const siteUrl = import.meta.env.PUBLIC_SITE_URL
-const canonicalUrl = new URL(Astro.url.pathname, siteUrl)
+const canonicalUrl = Astro.site ? new URL(Astro.url.pathname, Astro.site) : null
 ---
 
 <!doctype html>

--- a/src/lib/stores/version-group.ts
+++ b/src/lib/stores/version-group.ts
@@ -9,12 +9,10 @@ const versionGroupStore = new Store<{ versionGroup: VersionGroupKey }>({
 })
 
 const setVersionGroup = (versionGroup: VersionGroupKey) => {
-  versionGroupStore.setState(() => ({ versionGroup }))
+  if (typeof window === 'undefined') return
 
-  // Update localStorage
-  if (typeof window !== 'undefined') {
-    localStorage.setItem('version_group', versionGroup)
-  }
+  versionGroupStore.setState(() => ({ versionGroup }))
+  localStorage.setItem('version_group', versionGroup)
 }
 
 const isValidVersionGroupKey = (value: unknown): value is VersionGroupKey => {
@@ -23,20 +21,20 @@ const isValidVersionGroupKey = (value: unknown): value is VersionGroupKey => {
 
 // Create selector hooks for components
 export function useVersionGroup() {
-  const versionGroup = useSelector(versionGroupStore, (state) => state.versionGroup)
   const [hasMounted, setHasMounted] = useState(false)
+  const versionGroup = useSelector(versionGroupStore, (state) => state.versionGroup)
 
   useEffect(() => {
+    if (typeof window === 'undefined') return
+
     setHasMounted(true)
-    if (typeof window !== 'undefined') {
-      const storedValue = localStorage.getItem('version_group')
-      if (storedValue && isValidVersionGroupKey(storedValue)) {
-        // Only update if the stored value differs from current state
-        if (versionGroup !== storedValue) {
-          versionGroupStore.setState(() => ({
-            versionGroup: storedValue as VersionGroupKey,
-          }))
-        }
+    const storedValue = localStorage.getItem('version_group')
+    if (storedValue && isValidVersionGroupKey(storedValue)) {
+      // Only update if the stored value differs from current state
+      if (versionGroup !== storedValue) {
+        versionGroupStore.setState(() => ({
+          versionGroup: storedValue as VersionGroupKey,
+        }))
       }
     }
   }, [versionGroup])

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,6 +1,10 @@
 @import url('https://fonts.googleapis.com/css2?family=Geist:ital,wght@0,100..900;1,100..900&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Sofia+Sans:ital,wght@0,1..1000;1,1..1000&display=swap');
 @import 'tailwindcss';
 
+@view-transition {
+  navigation: auto;
+}
+
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {


### PR DESCRIPTION
This pull request introduces several improvements and refactors across the codebase, focusing on enhanced navigation transitions, accessibility, state management robustness, and minor UI/UX refinements. The most significant changes include replacing the variant selector's radio group with accessible links for better navigation, adding support for View Transitions API to enable smoother UI updates, and improving state and theme initialization logic.

**Navigation and Accessibility Improvements:**

* Refactored `VariantCardSelector` to use accessible `Link` components instead of a `RadioGroup`, improving navigation semantics and allowing for smoother transitions between variants. The new implementation also updates the current page indication using `aria-current` and disables navigation for the selected variant. (`src/components/compounds/VariantCardSelector.tsx`) [[1]](diffhunk://#diff-b93b662a87f5b2452ccd6b5d87e62539684f8081e8917a49d25df0b11f0fcca2L1-R5) [[2]](diffhunk://#diff-b93b662a87f5b2452ccd6b5d87e62539684f8081e8917a49d25df0b11f0fcca2L20-R48)

**UI Transitions and Styling:**

* Added `viewTransitionName` styles to monster sprite images in both `MonsterCard` and `MonsterHero` components to support smooth transitions using the View Transitions API. (`src/components/compounds/MonsterCard.tsx`, `src/components/details/MonsterHero.tsx`) [[1]](diffhunk://#diff-b6d84052ca0c7a531827cbf8cce26410f3a2b381f40fb04633a69e0ea7273783R36) [[2]](diffhunk://#diff-a8639ecef9aa0774533ab2f710e113f4613a9aa8d1ce91d4d56480f6eba6872dR66)
* Enabled View Transitions API globally in `globals.css` for navigation transitions. (`src/styles/globals.css`)

**State Management and Initialization:**

* Improved theme initialization in `ThemeSwitch` by deferring rendering until the theme is loaded from localStorage, preventing hydration mismatches. (`src/components/shared/ThemeSwitch.tsx`)
* Enhanced `version-group` store logic to avoid state updates on the server and ensure localStorage is only accessed in the browser, improving SSR compatibility and reliability. (`src/lib/stores/version-group.ts`) [[1]](diffhunk://#diff-25bf4975732a6063511fccc05e1bdd823849dc4c88b9cd385ce8b4788a272696L12-L31) [[2]](diffhunk://#diff-25bf4975732a6063511fccc05e1bdd823849dc4c88b9cd385ce8b4788a272696L41)

**Layout and Metadata Handling:**

* Updated canonical URL logic in `Layout.astro` to use `Astro.site` if available, and added dark mode and antialiased text classes to the `<body>` for consistent styling. (`src/layouts/Layout.astro`) [[1]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2L16-R16) [[2]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2L57-R56)