### PR TITLE
refactor: centralize sprite/flavor-text helpers and harden catalog grid hydration

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
   "sortTailwindcss": {
-    "functions": ["tw", "clsx", "cva"]
+    "functions": ["tw", "clsx"]
   },
   "arrowParens": "always",
   "bracketSpacing": true,

--- a/lint-notes.txt
+++ b/lint-notes.txt
@@ -1,2 +1,0 @@
-// I set this to off for pokeapi stuff because I know the data.
-"noNonNullAssertion": "off",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@visx/shape": "^3.12.0",
     "astro": "7.0.0-beta.3",
     "clsx": "^2.1.1",
-    "cva": "1.0.0-beta.4",
     "lucide-react": "^1.17.0",
     "motion": "^12.40.0",
     "p-map": "^7.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      cva:
-        specifier: 1.0.0-beta.4
-        version: 1.0.0-beta.4(typescript@6.0.3)
       lucide-react:
         specifier: ^1.17.0
         version: 1.17.0(react@19.2.7)
@@ -1565,14 +1562,6 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
-
-  cva@1.0.0-beta.4:
-    resolution: {integrity: sha512-F/JS9hScapq4DBVQXcK85l9U91M6ePeXoBMSp7vypzShoefUBxjQTo3g3935PUHgQd+IW77DjbPRIxugy4/GCQ==}
-    peerDependencies:
-      typescript: '>= 4.5.5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   d3-array@3.2.1:
     resolution: {integrity: sha512-gUY/qeHq/yNqqoCKNq4vtpFLdoCdvyNpWoC/KNjhGbhDuQpAM9sIQQKkXSNpXa9h5KySs/gzm7R88WkUutgwWQ==}
@@ -4349,12 +4338,6 @@ snapshots:
       css-tree: 2.2.1
 
   csstype@3.2.3: {}
-
-  cva@1.0.0-beta.4(typescript@6.0.3):
-    dependencies:
-      clsx: 2.1.1
-    optionalDependencies:
-      typescript: 6.0.3
 
   d3-array@3.2.1:
     dependencies:

--- a/src/components/GlassCard.tsx
+++ b/src/components/GlassCard.tsx
@@ -1,41 +1,38 @@
 import clsx from 'clsx/lite'
-import { cva, type VariantProps } from 'cva'
 
-const variants = cva({
-  base: '',
-  variants: {
-    variant: {
-      default: '',
-      // link: 'transition-colors hover:from-zinc-200/60 hover:to-zinc-300/60 hover:inset-ring-zinc-300/60 hover:duration-0 dark:hover:from-zinc-800/60 dark:hover:to-zinc-700/60 dark:hover:inset-ring-zinc-700/60',
-      link: 'transition-colors hover:bg-zinc-200/60 hover:inset-ring-zinc-300/60 hover:duration-0 dark:hover:bg-zinc-800/60 dark:hover:inset-ring-zinc-700/60',
-    },
-    transparency: {
-      opaque:
-        // 'from-zinc-50 to-zinc-100 inset-ring-1 inset-ring-zinc-200 dark:from-zinc-900 dark:to-zinc-950 dark:inset-ring-zinc-800',
-        'bg-zinc-50 inset-ring-1 inset-ring-zinc-100 dark:bg-zinc-950 dark:inset-ring-zinc-900',
-      transparent:
-        // 'from-zinc-50/60 to-zinc-100/60 inset-ring-1 inset-ring-zinc-200/60 backdrop-blur-xl dark:from-zinc-900/60 dark:to-zinc-950/60 dark:inset-ring-zinc-800',
-        'bg-zinc-100/50 inset-ring-1 inset-ring-zinc-200/50 backdrop-blur-xl dark:bg-zinc-900/50 dark:inset-ring-zinc-800/50',
-    },
-  },
-  defaultVariants: {
-    variant: 'default',
-    transparency: 'transparent',
-  },
-})
+type GlassVariant = 'default' | 'link'
+type GlassTransparency = 'opaque' | 'transparent'
+
+const variantClasses: Record<GlassVariant, string> = {
+  default: '',
+  // link: 'transition-colors hover:from-zinc-200/60 hover:to-zinc-300/60 hover:inset-ring-zinc-300/60 hover:duration-0 dark:hover:from-zinc-800/60 dark:hover:to-zinc-700/60 dark:hover:inset-ring-zinc-700/60',
+  link: 'transition-colors hover:bg-zinc-200/60 hover:inset-ring-zinc-300/60 hover:duration-0 dark:hover:bg-zinc-800/60 dark:hover:inset-ring-zinc-700/60',
+}
+
+const transparencyClasses: Record<GlassTransparency, string> = {
+  // opaque: 'from-zinc-50 to-zinc-100 inset-ring-1 inset-ring-zinc-200 dark:from-zinc-900 dark:to-zinc-950 dark:inset-ring-zinc-800',
+  opaque: 'bg-zinc-50 inset-ring-1 inset-ring-zinc-100 dark:bg-zinc-950 dark:inset-ring-zinc-900',
+  // transparent: 'from-zinc-50/60 to-zinc-100/60 inset-ring-1 inset-ring-zinc-200/60 backdrop-blur-xl dark:from-zinc-900/60 dark:to-zinc-950/60 dark:inset-ring-zinc-800',
+  transparent:
+    'bg-zinc-100/50 inset-ring-1 inset-ring-zinc-200/50 backdrop-blur-xl dark:bg-zinc-900/50 dark:inset-ring-zinc-800/50',
+}
 
 export default function GlassCard({
   children,
   className,
-  variant,
-  transparency,
+  variant = 'default',
+  transparency = 'transparent',
   ...props
 }: {
   children: React.ReactNode
-} & VariantProps<typeof variants> &
-  React.ComponentPropsWithoutRef<'div'>) {
+  variant?: GlassVariant
+  transparency?: GlassTransparency
+} & React.ComponentPropsWithoutRef<'div'>) {
   return (
-    <div {...props} className={clsx(className, variants({ variant, transparency }))}>
+    <div
+      {...props}
+      className={clsx(className, variantClasses[variant], transparencyClasses[transparency])}
+    >
       {children}
     </div>
   )

--- a/src/components/TypePill.astro
+++ b/src/components/TypePill.astro
@@ -1,22 +1,17 @@
 ---
-import { cva } from 'cva'
-
 import { TYPES, type TypeKey } from '@/lib/domain/types'
 
-const variants = cva({
-  base: 'flex flex-row items-center',
-  variants: {
-    size: {
-      small: 'w-24 gap-1.5 rounded-xs text-xs font-normal tracking-tight',
-      medium: 'w-28 gap-2 rounded-sm p-0.5 text-xs font-semibold tracking-wide',
-      large: 'w-32 gap-2.5 rounded-md p-1 text-sm font-semibold tracking-wider',
-    },
-  },
-})
+type PillSize = 'small' | 'medium' | 'large'
+
+const sizeClasses: Record<PillSize, string> = {
+  small: 'w-24 gap-1.5 rounded-xs text-xs font-normal tracking-tight',
+  medium: 'w-28 gap-2 rounded-sm p-0.5 text-xs font-semibold tracking-wide',
+  large: 'w-32 gap-2.5 rounded-md p-1 text-sm font-semibold tracking-wider',
+}
 
 interface Props {
   variant: string
-  size?: 'small' | 'medium' | 'large'
+  size?: PillSize
   class?: string
 }
 
@@ -26,7 +21,7 @@ const imageUrl = `${variant}.png`
 const dimensions = { small: 20, medium: 24, large: 28 }
 ---
 
-<div class:list={[variants({ size }), 'bg-zinc-200 dark:bg-zinc-800', className]}>
+<div class:list={['flex flex-row items-center', sizeClasses[size], 'bg-zinc-200 dark:bg-zinc-800', className]}>
   <img
     src={imageUrl}
     alt={name}

--- a/src/components/compounds/CardGrid.tsx
+++ b/src/components/compounds/CardGrid.tsx
@@ -14,7 +14,7 @@ import {
   type RowData,
 } from '@tanstack/react-table'
 import { AnimatePresence, motion } from 'motion/react'
-import { type ReactNode } from 'react'
+import { useEffect, type ReactNode } from 'react'
 
 import Pagination from '@/components/compounds/Pagination'
 import FilterBar, { type FilterOption } from '@/components/shared/FilterBar'
@@ -151,6 +151,14 @@ export default function CardGrid<T extends RowData>({
     [globalFilter, sorting, columnFilters, pagination]
   )
 
+  // Clamp page index to valid range when data or filters change, to avoid showing empty page.
+  const pageCount = table.getPageCount()
+  useEffect(() => {
+    if (pageCount > 0 && pagination.pageIndex > pageCount - 1) {
+      table.setPageIndex(pageCount - 1)
+    }
+  }, [pageCount, pagination.pageIndex, table])
+
   const handleSearchChange = (value: string) => {
     table.setGlobalFilter(value)
     table.firstPage()
@@ -187,7 +195,7 @@ export default function CardGrid<T extends RowData>({
 
   const pageRows = table.getRowModel().rows
   const hasResults = table.getFilteredRowModel().rows.length > 0
-  const totalPages = table.getPageCount()
+  const totalPages = pageCount
   const currentPage = pagination.pageIndex + 1
 
   return (

--- a/src/components/compounds/CardGrid.tsx
+++ b/src/components/compounds/CardGrid.tsx
@@ -89,31 +89,41 @@ export default function CardGrid<T extends RowData>({
     features: cardGridFeatures,
     columns,
     data: rows,
+    // Defaults only; the URL is applied after mount (see effect) to match the
+    // param-less server render and avoid a hydration mismatch.
     initialState: {
-      globalFilter: readParam('q') ?? '',
-      sorting: sort
-        ? [
-            {
-              id: readParam('sort') ?? sort.defaultKey,
-              desc: (readParam('dir') as SortDirection) === 'desc',
-            },
-          ]
-        : [],
-      columnFilters: filters
-        .map((filter) => ({
-          id: filter.id,
-          value: readParam(filter.param)?.split(',').filter(Boolean) ?? [],
-        }))
-        .filter((entry) => entry.value.length > 0),
-      pagination: {
-        pageIndex: (Number(readParam('p')) || DEFAULT_PAGE) - 1,
-        pageSize: itemsPerPage,
-      },
+      globalFilter: '',
+      sorting: sort ? [{ id: sort.defaultKey, desc: false }] : [],
+      columnFilters: [],
+      pagination: { pageIndex: 0, pageSize: itemsPerPage },
     },
     autoResetPageIndex: false,
   })
 
   const { globalFilter, sorting, columnFilters, pagination } = table.state
+
+  // Two-pass seeding: restore q/sort/dir/filters/page from the URL once, after hydration.
+  useEffect(() => {
+    const search = readParam('q')
+    if (search) table.setGlobalFilter(search)
+
+    if (sort) {
+      const key = readParam('sort')
+      const dir = readParam('dir')
+      if (key || dir) table.setSorting([{ id: key ?? sort.defaultKey, desc: dir === 'desc' }])
+    }
+
+    const seededFilters = filters
+      .map((filter) => ({
+        id: filter.id,
+        value: readParam(filter.param)?.split(',').filter(Boolean) ?? [],
+      }))
+      .filter((entry) => entry.value.length > 0)
+    if (seededFilters.length > 0) table.setColumnFilters(seededFilters)
+
+    const page = Number(readParam('p'))
+    if (page > DEFAULT_PAGE) table.setPageIndex(page - 1)
+  }, [])
 
   const activeFilterValues: Record<string, string[]> = Object.fromEntries(
     filters.map((filter) => [

--- a/src/components/compounds/InfoCard.tsx
+++ b/src/components/compounds/InfoCard.tsx
@@ -3,6 +3,7 @@ import { memo } from 'react'
 
 import { Badge } from '@/components/ui/catalyst/badge'
 import { useVersionGroup } from '@/lib/stores/version-group'
+import { resolveFlavorText } from '@/lib/utils/pokeapi-helpers'
 
 type Tag = {
   label: string
@@ -22,16 +23,8 @@ export type InfoCardProps = {
 const InfoCard = ({ props }: { props: InfoCardProps }) => {
   const { versionGroup } = useVersionGroup()
 
-  const description = (() => {
-    const entry = props.flavorTextEntries.find(
-      (entry) => entry.language.name === 'en' && entry.version_group?.name === versionGroup
-    )
-    if (!entry) return props.defaultDescription
-    if ('text' in entry) return entry.text
-    if ('flavor_text' in entry) return entry.flavor_text
-
-    return props.defaultDescription
-  })()
+  const description =
+    resolveFlavorText(props.flavorTextEntries, versionGroup) ?? props.defaultDescription
 
   return (
     <div className="h-full rounded-xl bg-zinc-100/50 inset-ring-1 inset-ring-zinc-200/50 backdrop-blur-xl dark:bg-zinc-900/50 dark:inset-ring-zinc-800/50">

--- a/src/components/compounds/ItemCard.tsx
+++ b/src/components/compounds/ItemCard.tsx
@@ -9,6 +9,7 @@ import {
   type ItemPocketKey,
 } from '@/lib/domain/items'
 import { useVersionGroup } from '@/lib/stores/version-group'
+import { resolveFlavorText } from '@/lib/utils/pokeapi-helpers'
 
 export type ItemCardProps = {
   id: number
@@ -24,16 +25,8 @@ export type ItemCardProps = {
 const ItemCard = ({ props }: { props: ItemCardProps }) => {
   const { versionGroup } = useVersionGroup()
 
-  const description = (() => {
-    const entry = props.flavorTextEntries.find(
-      (entry) => entry.language.name === 'en' && entry.version_group?.name === versionGroup
-    )
-    if (!entry) return props.defaultDescription
-    if ('text' in entry) return entry.text
-    if ('flavor_text' in entry) return entry.flavor_text
-
-    return props.defaultDescription
-  })()
+  const description =
+    resolveFlavorText(props.flavorTextEntries, versionGroup) ?? props.defaultDescription
 
   return (
     <div className="h-full rounded-xl bg-zinc-100/50 inset-ring-1 inset-ring-zinc-200/50 backdrop-blur-xl dark:bg-zinc-900/50 dark:inset-ring-zinc-800/50">

--- a/src/components/compounds/MonsterCard.tsx
+++ b/src/components/compounds/MonsterCard.tsx
@@ -3,6 +3,7 @@ import { memo } from 'react'
 import Link from '@/components/ui/catalyst/link'
 import type { TypeKey } from '@/lib/domain/types'
 import { toHref } from '@/lib/utils/path'
+import { monsterSpriteUrl } from '@/lib/utils/sprites'
 
 export type MonsterCardProps = {
   id: number
@@ -12,8 +13,7 @@ export type MonsterCardProps = {
 }
 
 const MonsterCard = ({ props }: { props: MonsterCardProps }) => {
-  const imageId = props.id.toString().padStart(4, '0')
-  const imageUrl = `https://raw.githubusercontent.com/blai30/PokemonSpritesDump/refs/heads/main/sprites/sprite_${imageId}_s0.webp`
+  const imageUrl = monsterSpriteUrl(props.id)
 
   return (
     <div className="h-full rounded-xl bg-zinc-100/50 inset-ring-1 inset-ring-zinc-200/50 backdrop-blur-xl transition-colors hover:bg-zinc-200/60 hover:inset-ring-zinc-300/60 hover:duration-0 dark:bg-zinc-900/50 dark:inset-ring-zinc-800/50 dark:hover:bg-zinc-800/60 dark:hover:inset-ring-zinc-700/60">

--- a/src/components/compounds/MoveCard.tsx
+++ b/src/components/compounds/MoveCard.tsx
@@ -5,14 +5,13 @@ import { TypeIcon } from '@/components/icons'
 import { DAMAGE_CLASSES, type DamageClassKey } from '@/lib/domain/damage-class'
 import type { MoveInfo } from '@/lib/domain/moves'
 import { useVersionGroup } from '@/lib/stores/version-group'
+import { resolveFlavorText } from '@/lib/utils/pokeapi-helpers'
 
 const MoveCard = ({ props }: { props: MoveInfo }) => {
   const { versionGroup } = useVersionGroup()
 
   const description =
-    props.flavorTextEntries.find(
-      (entry) => entry.language.name === 'en' && entry.version_group?.name === versionGroup
-    )?.flavor_text ?? props.defaultDescription
+    resolveFlavorText(props.flavorTextEntries, versionGroup) ?? props.defaultDescription
 
   return (
     <div className="relative h-full rounded-xl bg-white inset-ring-1 inset-ring-zinc-100 backdrop-blur-xl dark:bg-black dark:inset-ring-zinc-900">

--- a/src/components/details/MonsterHero.astro
+++ b/src/components/details/MonsterHero.astro
@@ -3,6 +3,7 @@ import type { Pokemon, PokemonForm, PokemonSpecies } from 'pokedex-promise-v2'
 
 import TypePill from '@/components/TypePill.astro'
 import { getTranslation } from '@/lib/utils/pokeapi-helpers'
+import { monsterSpriteUrl } from '@/lib/utils/sprites'
 
 interface Props {
   species: PokemonSpecies
@@ -18,9 +19,7 @@ const name =
   getTranslation(species.names, 'name')!
 
 const imageId = species.id.toString().padStart(4, '0')
-const imageUrl = pokemon.is_default
-  ? `https://raw.githubusercontent.com/blai30/PokemonSpritesDump/refs/heads/main/sprites/sprite_${imageId}_s0.webp`
-  : `https://raw.githubusercontent.com/blai30/PokemonSpritesDump/refs/heads/main/sprites/sprite_${imageId}_${pokemon.name}_s0.webp`
+const imageUrl = monsterSpriteUrl(species.id, pokemon.is_default ? undefined : pokemon.name)
 
 const leadingZeros = imageId.match(/^0+/)?.[0] || ''
 const significantDigits = imageId.slice(leadingZeros.length)

--- a/src/components/details/abilities/AbilityEntry.tsx
+++ b/src/components/details/abilities/AbilityEntry.tsx
@@ -2,23 +2,16 @@ import { Sparkles } from 'lucide-react'
 
 import type { AbilityEntryProps } from '@/lib/domain/abilities'
 import { useVersionGroup } from '@/lib/stores/version-group'
-import { getTranslation } from '@/lib/utils/pokeapi-helpers'
+import { getTranslation, resolveFlavorText } from '@/lib/utils/pokeapi-helpers'
 
 export default function AbilityEntry({ props }: { props: AbilityEntryProps }) {
   const { versionGroup } = useVersionGroup()
   const name = getTranslation(props.resource.names, 'name')!
 
-  const description = (() => {
-    const defaultDescription = getTranslation(props.resource.effect_entries, 'short_effect') ?? ''
-    const entry = props.resource.flavor_text_entries.find(
-      (entry) => entry.language.name === 'en' && entry.version_group?.name === versionGroup
-    )
-    if (!entry) return defaultDescription
-    if ('text' in entry) return entry.text
-    if ('flavor_text' in entry) return entry.flavor_text
-
-    return defaultDescription
-  })()
+  const description =
+    resolveFlavorText(props.resource.flavor_text_entries, versionGroup) ??
+    getTranslation(props.resource.effect_entries, 'short_effect') ??
+    ''
 
   return (
     <div className="flex flex-col gap-1">

--- a/src/components/details/cosmetics/CosmeticsSection.astro
+++ b/src/components/details/cosmetics/CosmeticsSection.astro
@@ -2,6 +2,7 @@
 import type { Pokemon, PokemonForm } from 'pokedex-promise-v2'
 
 import { getTranslation } from '@/lib/utils/pokeapi-helpers'
+import { monsterSpriteUrl } from '@/lib/utils/sprites'
 
 interface Props {
   pokemon: Pokemon
@@ -10,7 +11,6 @@ interface Props {
 
 const { pokemon, forms } = Astro.props
 const cosmeticForms = forms.filter((form) => form.name !== pokemon.name)
-const imageId = pokemon.id.toString().padStart(4, '0')
 ---
 
 <section
@@ -29,9 +29,7 @@ const imageId = pokemon.id.toString().padStart(4, '0')
     >
       {cosmeticForms.map((form) => {
         const name = getTranslation(form.form_names, 'name')!
-        const imageUrl = form.is_default
-          ? `https://raw.githubusercontent.com/blai30/PokemonSpritesDump/refs/heads/main/sprites/sprite_${imageId}_s0.webp`
-          : `https://raw.githubusercontent.com/blai30/PokemonSpritesDump/refs/heads/main/sprites/sprite_${imageId}_${form.name}_s0.webp`
+        const imageUrl = monsterSpriteUrl(pokemon.id, form.is_default ? undefined : form.name)
         return (
           <li
             class="flex flex-col items-center gap-2 rounded-lg bg-linear-to-br from-white to-zinc-100 p-4 dark:from-zinc-900 dark:to-zinc-950"

--- a/src/components/details/evolution/EvolutionMonster.astro
+++ b/src/components/details/evolution/EvolutionMonster.astro
@@ -5,6 +5,7 @@ import { TypeIcon } from '@/components/icons'
 import { toHref } from '@/lib/utils/path'
 import type { TypeKey } from '@/lib/domain/types'
 import { getTranslation } from '@/lib/utils/pokeapi-helpers'
+import { monsterSpriteUrl } from '@/lib/utils/sprites'
 
 interface Props {
   species: PokemonSpecies
@@ -14,8 +15,7 @@ interface Props {
 
 const { species, pokemon, current = false } = Astro.props
 const name = getTranslation(species.names, 'name')
-const imageId = species.id.toString().padStart(4, '0')
-const imageUrl = `https://raw.githubusercontent.com/blai30/PokemonSpritesDump/refs/heads/main/sprites/sprite_${imageId}_s0.webp`
+const imageUrl = monsterSpriteUrl(species.id)
 ---
 
 <div

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx/lite'
-import { cva } from 'cva'
 
 import { DAMAGE_CLASSES, type DamageClassKey } from '@/lib/domain/damage-class'
 import { TYPES, type TypeKey } from '@/lib/domain/types'
@@ -12,16 +11,11 @@ type IconProps = {
   className?: string
 }
 
-const variants = cva({
-  base: 'relative flex flex-row items-center justify-center',
-  variants: {
-    size: {
-      small: 'size-5 rounded-xs',
-      medium: 'size-6 rounded-sm',
-      large: 'size-8 rounded-md',
-    },
-  },
-})
+const sizeClasses: Record<IconSize, string> = {
+  small: 'size-5 rounded-xs',
+  medium: 'size-6 rounded-sm',
+  large: 'size-8 rounded-md',
+}
 
 const dimensions: Record<IconSize, number> = {
   small: 20,
@@ -38,7 +32,16 @@ function IconBadge({
   ...props
 }: IconProps & { name: string; imgClassName?: string }) {
   return (
-    <div {...props} title={name} className={clsx(`bg-${variant}`, variants({ size }), className)}>
+    <div
+      {...props}
+      title={name}
+      className={clsx(
+        'relative flex flex-row items-center justify-center',
+        `bg-${variant}`,
+        sizeClasses[size],
+        className
+      )}
+    >
       <img
         src={`${variant}.png`}
         alt={name}

--- a/src/lib/api/moves-client.ts
+++ b/src/lib/api/moves-client.ts
@@ -11,20 +11,30 @@ let descriptionsPromise: Promise<MovesDescriptionsMap> | null = null
 
 export function loadMovesData(): Promise<MovesDataMap> {
   if (!movesDataPromise) {
-    movesDataPromise = fetch(resolvePath('/data/moves-data.json')).then((response) => {
-      if (!response.ok) throw new Error(`Failed to load moves data: ${response.status}`)
-      return response.json() as Promise<MovesDataMap>
-    })
+    movesDataPromise = fetch(resolvePath('/data/moves-data.json'))
+      .then((response) => {
+        if (!response.ok) throw new Error(`Failed to load moves data: ${response.status}`)
+        return response.json() as Promise<MovesDataMap>
+      })
+      .catch((error) => {
+        movesDataPromise = null
+        throw error
+      })
   }
   return movesDataPromise
 }
 
 export function loadMovesDescriptions(): Promise<MovesDescriptionsMap> {
   if (!descriptionsPromise) {
-    descriptionsPromise = fetch(resolvePath('/data/moves-descriptions.json')).then((response) => {
-      if (!response.ok) throw new Error(`Failed to load move descriptions: ${response.status}`)
-      return response.json() as Promise<MovesDescriptionsMap>
-    })
+    descriptionsPromise = fetch(resolvePath('/data/moves-descriptions.json'))
+      .then((response) => {
+        if (!response.ok) throw new Error(`Failed to load move descriptions: ${response.status}`)
+        return response.json() as Promise<MovesDescriptionsMap>
+      })
+      .catch((error) => {
+        descriptionsPromise = null
+        throw error
+      })
   }
   return descriptionsPromise
 }

--- a/src/lib/domain/effectiveness.ts
+++ b/src/lib/domain/effectiveness.ts
@@ -21,7 +21,7 @@ export type TypeRelation = {
   effectiveness: number
 }
 
-export function getEffectiveness(...typeResources: Type[]): TypeEffectiveness {
+function getEffectiveness(...typeResources: Type[]): TypeEffectiveness {
   // Initialize all types with neutral effectiveness.
   const effectiveness = Object.fromEntries(TYPE_KEYS.map((type) => [type, 1])) as TypeEffectiveness
 
@@ -59,7 +59,7 @@ const typeEffectiveness: Record<TypeKey, TypeEffectiveness> = {} as Record<
 >
 let typesInitPromise: Promise<Record<TypeKey, Type>> | undefined
 
-export const initTypes = async (): Promise<Record<TypeKey, Type>> => {
+const initTypes = async (): Promise<Record<TypeKey, Type>> => {
   if (typesInitPromise) return typesInitPromise
 
   typesInitPromise = (async () => {
@@ -78,7 +78,7 @@ export const initTypes = async (): Promise<Record<TypeKey, Type>> => {
   return typesInitPromise
 }
 
-export function getCombinedEffectiveness(typeKeys: TypeKey[]): TypeEffectiveness {
+function getCombinedEffectiveness(typeKeys: TypeKey[]): TypeEffectiveness {
   const base = Object.fromEntries(TYPE_KEYS.map((k) => [k, 1])) as TypeEffectiveness
 
   for (const typeKey of typeKeys) {
@@ -91,4 +91,14 @@ export function getCombinedEffectiveness(typeKeys: TypeKey[]): TypeEffectiveness
     }
   }
   return base
+}
+
+// Type matchups for a monster, against every attacking type.
+export async function getTypeRelations(typeKeys: TypeKey[]): Promise<TypeRelation[]> {
+  const allTypes = await initTypes()
+  const effectiveness = getCombinedEffectiveness(typeKeys)
+  return TYPE_KEYS.map((typeKey) => ({
+    type: allTypes[typeKey],
+    effectiveness: effectiveness[typeKey],
+  }))
 }

--- a/src/lib/domain/evolution.ts
+++ b/src/lib/domain/evolution.ts
@@ -3,13 +3,9 @@ import type {
   EvolutionChain,
   EvolutionDetail,
   Item,
-  Location,
-  Move,
   Name,
   Pokemon,
   PokemonSpecies,
-  Region,
-  Type,
 } from 'pokedex-promise-v2'
 
 import pokeapi from '@/lib/api/pokeapi'
@@ -55,6 +51,12 @@ const itemChip = (item: Item, label: string): Chip =>
     ? { label, icon: { type: 'item', url: item.sprites.default } }
     : { label, icon: { type: 'lucide', name: 'gem' } }
 
+// Fetch a referenced resource and return its localized display name, falling back to the slug.
+const resolveName = async (ref: { name: string; url: string }): Promise<string> => {
+  const resource = await pokeapi.getResource<{ names: Name[] }>(ref.url)
+  return getTranslation(resource.names, 'name') ?? ref.name
+}
+
 // Maps one pokeapi EvolutionDetail to localized chips plus a full-sentence
 // tooltip. Async because most conditions reference another resource whose
 // localized display name must be fetched (deduped by the build-time cache).
@@ -66,7 +68,7 @@ export const describeEvolution = async (
   let head = 'Level up'
   const mods: string[] = []
 
-  const trigger = detail.trigger?.name ?? 'level-up'
+  const trigger = detail.trigger.name ?? 'level-up'
 
   // Base trigger and its primary chip.
   if (trigger === 'use-item' && detail.item) {
@@ -76,8 +78,7 @@ export const describeEvolution = async (
     head = `Use ${name}`
   } else if (trigger === 'trade') {
     if (detail.trade_species) {
-      const species = await pokeapi.getResource<PokemonSpecies>(detail.trade_species.url)
-      const name = getTranslation(species.names, 'name') ?? detail.trade_species.name
+      const name = await resolveName(detail.trade_species)
       chips.push({ label: `Trade for ${name}`, icon: { type: 'lucide', name: 'arrow-left-right' } })
       head = `Trade for ${name}`
     } else {
@@ -96,8 +97,7 @@ export const describeEvolution = async (
   } else {
     // spin, tower-of-darkness/water, three-critical-hits, take-damage,
     // recoil-damage, agile/strong-style-move, other, and any future trigger.
-    const trig = await pokeapi.getResource<{ names: Name[] }>(detail.trigger.url)
-    const name = getTranslation(trig.names, 'name') ?? detail.trigger.name
+    const name = await resolveName(detail.trigger)
     chips.push({ label: name, icon: { type: 'lucide', name: 'arrow-up' } })
     head = name
   }
@@ -141,14 +141,12 @@ export const describeEvolution = async (
 
   // Known move and known move type.
   if (detail.known_move) {
-    const move = await pokeapi.getResource<Move>(detail.known_move.url)
-    const name = getTranslation(move.names, 'name') ?? detail.known_move.name
+    const name = await resolveName(detail.known_move)
     chips.push({ label: `Knows ${name}`, icon: { type: 'lucide', name: 'swords' } })
     mods.push(`knowing ${name}`)
   }
   if (detail.known_move_type) {
-    const type = await pokeapi.getResource<Type>(detail.known_move_type.url)
-    const name = getTranslation(type.names, 'name') ?? detail.known_move_type.name
+    const name = await resolveName(detail.known_move_type)
     chips.push({
       label: `${name} move`,
       icon: { type: 'pokemon-type', key: detail.known_move_type.name as TypeKey },
@@ -158,28 +156,24 @@ export const describeEvolution = async (
 
   // Location and region.
   if (detail.location) {
-    const location = await pokeapi.getResource<Location>(detail.location.url)
-    const name = getTranslation(location.names, 'name') ?? detail.location.name
+    const name = await resolveName(detail.location)
     chips.push({ label: name, icon: { type: 'lucide', name: 'map-pin' } })
     mods.push(`at ${name}`)
   }
   if (detail.region) {
-    const region = await pokeapi.getResource<Region>(detail.region.url)
-    const name = getTranslation(region.names, 'name') ?? detail.region.name
+    const name = await resolveName(detail.region)
     chips.push({ label: name, icon: { type: 'lucide', name: 'map-pin' } })
     mods.push(`in ${name}`)
   }
 
   // Party requirements.
   if (detail.party_species) {
-    const species = await pokeapi.getResource<PokemonSpecies>(detail.party_species.url)
-    const name = getTranslation(species.names, 'name') ?? detail.party_species.name
+    const name = await resolveName(detail.party_species)
     chips.push({ label: `${name} in party`, icon: { type: 'lucide', name: 'users' } })
     mods.push(`with ${name} in the party`)
   }
   if (detail.party_type) {
-    const type = await pokeapi.getResource<Type>(detail.party_type.url)
-    const name = getTranslation(type.names, 'name') ?? detail.party_type.name
+    const name = await resolveName(detail.party_type)
     chips.push({
       label: `${name} in party`,
       icon: { type: 'pokemon-type', key: detail.party_type.name as TypeKey },

--- a/src/lib/domain/locations.ts
+++ b/src/lib/domain/locations.ts
@@ -71,8 +71,8 @@ export async function buildLocationRows(pokemon: Pokemon): Promise<LocationEncou
 
     for (const versionDetail of encounter.version_details) {
       const version = versionMap[versionDetail.version.name]
-      const versionGroup = version.version_group.name as VersionGroupKey
       const versionName = getTranslation(version?.names, 'name') ?? versionDetail.version.name
+      const versionGroup = version.version_group.name as VersionGroupKey
       const key = `${area.name}__${versionGroup}__${versionDetail.version.name}`
       const methods = [
         ...new Set(

--- a/src/lib/domain/moves.ts
+++ b/src/lib/domain/moves.ts
@@ -2,7 +2,7 @@ import pMap from 'p-map'
 import type { FlavorText, Machine, Move, MoveElement, Pokemon } from 'pokedex-promise-v2'
 
 import pokeapi from '@/lib/api/pokeapi'
-import { getTranslation } from '@/lib/utils/pokeapi-helpers'
+import { getTranslation, resolveFlavorText } from '@/lib/utils/pokeapi-helpers'
 
 export type MoveInfo = {
   id: string
@@ -76,9 +76,7 @@ export function buildMoveData(move: Move): MoveData {
 
 export function resolveMoveDescription(move: Move, versionGroup: string): string {
   return (
-    move.flavor_text_entries.find(
-      (entry) => entry.language.name === 'en' && entry.version_group?.name === versionGroup
-    )?.flavor_text ??
+    resolveFlavorText(move.flavor_text_entries, versionGroup) ??
     getTranslation(move.effect_entries, 'short_effect') ??
     ''
   )

--- a/src/lib/utils/pokeapi-helpers.ts
+++ b/src/lib/utils/pokeapi-helpers.ts
@@ -4,6 +4,7 @@ import type { Pokemon, PokemonForm, PokemonSpecies } from 'pokedex-promise-v2'
 import pokeapi from '@/lib/api/pokeapi'
 import type { TypeKey } from '@/lib/domain/types'
 import { excludedVariants } from '@/lib/utils/excluded-slugs'
+import { monsterSpriteUrl } from '@/lib/utils/sprites'
 
 export function getTranslation<
   T extends {
@@ -64,8 +65,6 @@ export const createMonster = async (
     getTranslation(form?.names, 'name') ??
     getTranslation(species.names, 'name')!
 
-  const imageId = species.id.toString().padStart(4, '0')
-
   return {
     id: species.id,
     key: variant.name,
@@ -74,9 +73,7 @@ export const createMonster = async (
     pokemonSlug: variant.name ?? undefined,
     formSlug: form?.name ?? undefined,
     types: variant.types.map((t) => t.type.name as TypeKey) ?? undefined,
-    imageUrl: variant.is_default
-      ? `https://raw.githubusercontent.com/blai30/PokemonSpritesDump/refs/heads/main/sprites/sprite_${imageId}_s0.webp`
-      : `https://raw.githubusercontent.com/blai30/PokemonSpritesDump/refs/heads/main/sprites/sprite_${imageId}_${variant.name}_s0.webp`,
+    imageUrl: monsterSpriteUrl(species.id, variant.is_default ? undefined : variant.name),
   } as Monster
 }
 

--- a/src/lib/utils/pokeapi-helpers.ts
+++ b/src/lib/utils/pokeapi-helpers.ts
@@ -22,6 +22,23 @@ export function getTranslation<
   return String(resource[field])
 }
 
+export type FlavorTextEntry = {
+  language: { name: string }
+  version_group?: { name: string } | null
+  flavor_text?: string
+  text?: string
+}
+
+export function resolveFlavorText(
+  entries: FlavorTextEntry[],
+  versionGroup: string
+): string | undefined {
+  const entry = entries.find(
+    (e) => e.language.name === 'en' && e.version_group?.name === versionGroup
+  )
+  return entry?.text ?? entry?.flavor_text
+}
+
 export type Monster = {
   id: number
   key: string

--- a/src/lib/utils/sprites.ts
+++ b/src/lib/utils/sprites.ts
@@ -1,0 +1,13 @@
+const SPRITE_HOST = 'https://raw.githubusercontent.com/blai30/PokemonSpritesDump/refs/heads/main'
+
+// Monster sprite for a species. Pass variantName only for non-default variants.
+export function monsterSpriteUrl(speciesId: number, variantName?: string): string {
+  const imageId = speciesId.toString().padStart(4, '0')
+  return variantName
+    ? `${SPRITE_HOST}/sprites/sprite_${imageId}_${variantName}_s0.webp`
+    : `${SPRITE_HOST}/sprites/sprite_${imageId}_s0.webp`
+}
+
+export function itemSpriteUrl(name: string): string {
+  return `${SPRITE_HOST}/items/item_${name}.webp`
+}

--- a/src/pages/[slug]/[...variant].astro
+++ b/src/pages/[slug]/[...variant].astro
@@ -19,6 +19,7 @@ import { buildMovesData } from '@/lib/domain/moves'
 import { buildBaseStats } from '@/lib/domain/stats'
 import { TYPES, type TypeKey } from '@/lib/domain/types'
 import { getMonstersBySpecies, getTranslation } from '@/lib/utils/pokeapi-helpers'
+import { monsterSpriteUrl } from '@/lib/utils/sprites'
 import { excludedForms, excludedVariants } from '@/lib/utils/excluded-slugs'
 import MonsterHero from '@/components/details/MonsterHero.astro'
 import MonsterMetadata from '@/components/details/MonsterMetadata.astro'
@@ -106,7 +107,7 @@ const [
 
 // Metadata
 const imageId = species.id.toString().padStart(4, '0')
-const imageUrl = `https://raw.githubusercontent.com/blai30/PokemonSpritesDump/refs/heads/main/sprites/sprite_${imageId}_s0.webp`
+const imageUrl = monsterSpriteUrl(species.id)
 const name = getTranslation(species.names, 'name')!
 const description = pokemon.types
   .map((t) => TYPES[t.type.name as TypeKey])

--- a/src/pages/[slug]/[...variant].astro
+++ b/src/pages/[slug]/[...variant].astro
@@ -12,12 +12,12 @@ import Shell from '@/components/Shell.astro'
 import pokeapi from '@/lib/api/pokeapi'
 import { getSpeciesList } from '@/lib/providers'
 import { buildAbilitiesMap } from '@/lib/domain/abilities'
-import { getCombinedEffectiveness, initTypes, type TypeRelation } from '@/lib/domain/effectiveness'
+import { getTypeRelations } from '@/lib/domain/effectiveness'
 import { buildEvolutionTree } from '@/lib/domain/evolution'
 import { buildLocationRows } from '@/lib/domain/locations'
 import { buildMovesData } from '@/lib/domain/moves'
 import { buildBaseStats } from '@/lib/domain/stats'
-import { TYPES, TYPE_KEYS, type TypeKey } from '@/lib/domain/types'
+import { TYPES, type TypeKey } from '@/lib/domain/types'
 import { getMonstersBySpecies, getTranslation } from '@/lib/utils/pokeapi-helpers'
 import { excludedForms, excludedVariants } from '@/lib/utils/excluded-slugs'
 import MonsterHero from '@/components/details/MonsterHero.astro'
@@ -81,15 +81,9 @@ const form =
     ? undefined
     : forms.find((f) => f.name === variant || f.name === pokemon.name)
 
-// Fetch all 18 types once (cached across the entire build) and pre-compute effectiveness.
-const allTypes = await initTypes()
-// Compute type relations from pre-fetched types and pre-computed effectiveness.
+// Type matchups for this monster, against every attacking type.
 const typeKeys = pokemon.types.map((t) => t.type.name as TypeKey)
-const effectiveness = getCombinedEffectiveness(typeKeys)
-const typeRelations: TypeRelation[] = TYPE_KEYS.map((typeKey) => ({
-  type: allTypes[typeKey],
-  effectiveness: effectiveness[typeKey],
-}))
+const typeRelations = await getTypeRelations(typeKeys)
 
 // Build section data in parallel
 const [

--- a/src/pages/item.astro
+++ b/src/pages/item.astro
@@ -8,6 +8,7 @@ import pokeapi from '@/lib/api/pokeapi'
 import { getItemList } from '@/lib/providers'
 import { ITEM_CATEGORIES, type ItemCategoryKey, type ItemPocketKey } from '@/lib/domain/items'
 import { getTranslation } from '@/lib/utils/pokeapi-helpers'
+import { itemSpriteUrl } from '@/lib/utils/sprites'
 import { excludedItems } from '@/lib/utils/excluded-slugs'
 
 const itemList = await getItemList()
@@ -30,7 +31,7 @@ const itemsData = items
   )
   .map((resource) => {
     const { id, name, category } = resource
-    const imageUrl = `https://raw.githubusercontent.com/blai30/PokemonSpritesDump/refs/heads/main/items/item_${name}.webp`
+    const imageUrl = itemSpriteUrl(name)
     const pocket = ITEM_CATEGORIES[category.name as ItemCategoryKey].pocket
     return {
       id,


### PR DESCRIPTION
## Summary

This PR groups a round of catalog-grid reliability fixes with several refactors that pull duplicated lookups behind single centralized helpers. No behavior changes beyond the grid fixes; the rest consolidates existing logic.

## Changes

### Catalog grid reliability
- Seed `CardGrid` state from the URL after mount instead of during render, avoiding a hydration mismatch between the static HTML and the hydrated island.
- Clamp the page index when filtered results shrink so the grid never lands on an out-of-range page.
- Retry the moves-data fetch after a failure in `moves-client`, so a transient network error no longer leaves the moves section empty.

### Centralized helpers
- Add `lib/utils/sprites` and route all sprite URL construction (`MonsterCard`, `MonsterHero`, `CosmeticsSection`, `EvolutionMonster`, the detail route, and `item.astro`) through it instead of building URLs inline.
- Resolve version-group flavor text through one helper in `pokeapi-helpers`, replacing the duplicated lookups in `InfoCard`, `ItemCard`, `MoveCard`, `AbilityEntry`, and `moves`.
- Collapse type-effectiveness initialization behind `getTypeRelations` in `effectiveness`, simplifying the detail route.

## Verification
- `pnpm check`, `pnpm lint`, and `pnpm fmt` pass.